### PR TITLE
Update currency.sql

### DIFF
--- a/commands/currency.sql
+++ b/commands/currency.sql
@@ -24,6 +24,11 @@ VALUES
 		NULL,
 		NULL,
 		'(async function currency (context, amount, first, separator, second)  {
+	if (!second && !separator) {
+		second = first;
+		first = amount;
+		amount = \"1\";
+	}
 	if (!second) {
 		second = separator;
 		first = amount;


### PR DESCRIPTION
Enables command usage as follows:
$currency <currency1> <currency2>
Separator is not required and default amount is 1